### PR TITLE
Fix content parsing in entry_text for news pipeline

### DIFF
--- a/news_pipeline.py
+++ b/news_pipeline.py
@@ -124,11 +124,14 @@ def entry_text(entry) -> Tuple[str, str, str]:
     summary = getattr(entry, "summary", "") or getattr(entry, "description", "") or ""
     content = ""
     try:
-        if getattr(entry, "content", None):
-            content = (
-                " ".join((c.get("value") or "") for c in entry.content if isinstance(entry.content, list))
-                if isinstance(entry.content, list) else str(entry.content)
-            )
+        cont = getattr(entry, "content", None)
+        if cont:
+            if isinstance(cont, list):
+                content = " ".join((c.get("value") or "") for c in cont if isinstance(c, dict))
+            elif isinstance(cont, dict):
+                content = cont.get("value") or ""
+            else:
+                content = str(cont)
     except Exception:
         content = ""
     return title, summary, content


### PR DESCRIPTION
## Summary
- handle RSS entry content that's either a list of dictionaries or a single dictionary, ignoring non-dictionary elements

## Testing
- `python -m py_compile news_pipeline.py`
- `python - <<'PY'
from types import SimpleNamespace
from news_pipeline import entry_text
entry = SimpleNamespace(title='Title', summary='Sum', content=[{'value': 'A'}, {'value':'B'}, 'no'] )
print(entry_text(entry))
entry2 = SimpleNamespace(title=None, summary=None, content='text')
print(entry_text(entry2))
entry3 = SimpleNamespace(title=None, summary=None, content={'value':'dict', 'type':'html'})
print(entry_text(entry3))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689ac69a469c8326bdac889fea08566c