### PR TITLE
feat: make keyword search case insensitive

### DIFF
--- a/news_pipeline.py
+++ b/news_pipeline.py
@@ -134,8 +134,8 @@ def entry_text(entry) -> Tuple[str, str, str]:
     return title, summary, content
 
 def hit_by_keywords(title: str, summary: str, content: str, kws: List[str]) -> bool:
-    blob = f"{title} {summary} {content or ''}"
-    return any(k in blob for k in kws)
+    blob = f"{title} {summary} {content or ''}".lower()
+    return any(k.lower() in blob for k in kws)
 
 # ── sources.yml 读写（仅 RSS 源）─────────────────────────────────────────────
 def load_sources() -> List[Dict]:


### PR DESCRIPTION
## Summary
- make `hit_by_keywords` normalize text and keywords to lowercase

## Testing
- `python -m py_compile news_pipeline.py`
- `python - <<'PY'
from news_pipeline import hit_by_keywords
print(hit_by_keywords('Apple announces earnings', '', '', ['apple']))
print(hit_by_keywords('Apple announces earnings', '', '', ['APPLE']))
print(hit_by_keywords('APPLE announces earnings', '', '', ['apple']))
print(hit_by_keywords('Banana news', '', '', ['apple']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689ac7d310fc83268e03814a637d8cee