### PR TITLE
Handle Juhe API requests without keywords

### DIFF
--- a/news_pipeline.py
+++ b/news_pipeline.py
@@ -367,8 +367,9 @@ async def fetch_juhe_caijing(kws: List[str]) -> Tuple[str, List[Dict], str | Non
         async with httpx.AsyncClient(timeout=REQ_TIMEOUT) as c:
             batches = [kws[i:i+API_BATCH_KW] for i in range(0, len(kws), API_BATCH_KW)] or [[]]
             for b in batches:
-                if not b: continue
-                params = {"key": JUHE_KEY, "word": " ".join(b)}
+                params = {"key": JUHE_KEY}
+                if b:
+                    params["word"] = " ".join(b)
                 r = await c.get(base, params=params)
                 if r.status_code != 200:
                     logger.warning(f"juhe HTTP {r.status_code}")


### PR DESCRIPTION
## Summary
- Allow Juhe API to run even when keyword list is empty by omitting `word` param
- Add tests for empty keyword requests and recording parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c32b93d1c83269a4917851b3ea3c3