### PR TITLE
warn when optional API keys missing

### DIFF
--- a/news_pipeline.py
+++ b/news_pipeline.py
@@ -82,6 +82,14 @@ logger.handlers.clear(); logger.addHandler(sh)
 fh = logging.FileHandler(OUT_ERR, mode="w", encoding="utf-8")
 fh.setLevel(logging.WARNING); fh.setFormatter(_fmt); logger.addHandler(fh)
 
+# Warn once on missing optional API keys to aid debugging
+if not NEWSAPI_KEY:
+    logger.warning("NEWSAPI_KEY not set; skipping newsapi fetch")
+if not MEDIASTACK_KEY:
+    logger.warning("MEDIASTACK_KEY not set; skipping mediastack fetch")
+if not JUHE_KEY:
+    logger.warning("JUHE_KEY not set; skipping juhe_caijing fetch")
+
 def now_iso() -> str:
     return datetime.now(TZ).strftime("%Y-%m-%dT%H:%M:%S%z")
 


### PR DESCRIPTION
## Summary
- warn once at startup if NEWSAPI_KEY, MEDIASTACK_KEY, or JUHE_KEY are not set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3a3413f48326a545b0f16ef4844f