### PR TITLE
Add Qwen timeout overrides and request retries

### DIFF
--- a/daily_push_qwen.py
+++ b/daily_push_qwen.py
@@ -21,7 +21,9 @@ import httpx
 from datetime import datetime, timezone, timedelta
 
 TZ = timezone(timedelta(hours=8))
-REQ_TIMEOUT = httpx.Timeout(20.0, read=30.0)
+timeout = float(os.getenv("QWEN_TIMEOUT", "30"))
+read_timeout = float(os.getenv("QWEN_READ_TIMEOUT", "90"))
+REQ_TIMEOUT = httpx.Timeout(timeout, read=read_timeout)
 
 QWEN_API = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
 QWEN_MODEL = "qwen-plus-latest"
@@ -66,9 +68,18 @@ async def call_qwen(prompt: str) -> str:
     headers = {"Content-Type":"application/json","Authorization":f"Bearer {os.getenv('QWEN_API_KEY','')}"}
     payload = {"model": QWEN_MODEL, "input":{"prompt": prompt}, "parameters":{"max_tokens":900,"temperature":0.7}}
     async with httpx.AsyncClient(timeout=REQ_TIMEOUT) as c:
-        r = await c.post(QWEN_API, json=payload, headers=headers)
-        r.raise_for_status()
-        return r.json()["output"]["text"].strip()
+        for attempt in range(3):
+            try:
+                r = await c.post(QWEN_API, json=payload, headers=headers)
+                r.raise_for_status()
+                return r.json()["output"]["text"].strip()
+            except (httpx.ReadTimeout, httpx.RequestError) as e:
+                if attempt == 2:
+                    print(f"Qwen request failed after {attempt+1} attempts: {e}")
+                    raise
+                delay = 2 ** attempt
+                print(f"Qwen request error (attempt {attempt+1}/3): {e}; retrying in {delay}s")
+                await asyncio.sleep(delay)
 
 async def push_serverchan(text: str):
     key = os.getenv("SCKEY","").strip()


### PR DESCRIPTION
## Summary
- Allow configuring Qwen HTTP timeouts via `QWEN_TIMEOUT` and `QWEN_READ_TIMEOUT` env vars with higher defaults
- Add exponential backoff retry logic for Qwen POST requests catching `httpx.ReadTimeout` and `httpx.RequestError`

## Testing
- `pytest`
- `python -m py_compile daily_push_qwen.py`


------
https://chatgpt.com/codex/tasks/task_e_689eef74a51c8326acf6b7da363258d7