### PR TITLE
ci: expose MEDIASTACK_KEY in workflow

### DIFF
--- a/.github/workflows/daily_push.yml
+++ b/.github/workflows/daily_push.yml
@@ -25,6 +25,7 @@ jobs:
       QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
       JUHE_KEY: ${{ secrets.JUHE_KEY }}
       NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
+      MEDIASTACK_KEY: ${{ secrets.MEDIASTACK_KEY }}
       SCKEY: ${{ secrets.SCKEY }}
       TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
       TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
## Summary
- pass MEDIASTACK_KEY from repo secrets to the daily push workflow

## Testing
- `python -m py_compile news_pipeline.py daily_push_qwen.py holdings_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_689ef31608bc8326b6304398b38c5a3f