### PR TITLE
feat: split push templates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ feedparser==6.0.11
 beautifulsoup4==4.13.4
 lxml==6.0.0
 PyYAML==6.0.2
+markdown==3.6


### PR DESCRIPTION
## Summary
- add Markdown converters for HTML and text
- send HTML to Server酱 and plain text to Telegram
- declare markdown requirement

## Testing
- `python -m py_compile daily_push_qwen.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2d6add91c83268b89024ad35d0a53