### PR TITLE
Add a copyable AI usage prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 用于投资决策的长期规则库。
 
+## 最简单的实操
+
+把这句话复制给 AI：
+
+> 请先读取本仓库的投资规则，再读取 `invest-private/STATE.md`；如果私有状态没有数据，请明确说不知道，不要猜。
+
 ## 文件结构
 
 - `.agents/skills/investment-rules/SKILL.md`


### PR DESCRIPTION
## What changed

Added one copyable prompt to the public README. It tells AI to read the public investment rules together with the private `STATE.md`, and to avoid guessing when private state is missing.

## Why

This gives non-technical users one simple way to start using the two repositories together without adding scripts or extra workflow complexity.

## Checks

- `git diff --check`
- Confirmed only `README.md` is included in the commit
- Confirmed private repository content and local `AGENTS.md` are not included